### PR TITLE
Use makeMergedSchema

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@generated/photon": "0.0.0-generated",
-    "@hammerframework/api": "0.0.1-alpha.13.1"
+    "@hammerframework/api": "0.0.1-alpha.13.2"
   },
   "devDependencies": {
     "prisma2": "2.0.0-preview014",

--- a/api/package.json
+++ b/api/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@generated/photon": "0.0.0-generated",
-    "@hammerframework/hammer-api": "^0.0.1-alpha.12.2",
-    "nexus": "0.12.0-beta.14"
-
+    "@hammerframework/api": "0.0.1-alpha.13.1"
   },
   "devDependencies": {
     "prisma2": "2.0.0-preview014",

--- a/api/src/functions/graphql.js
+++ b/api/src/functions/graphql.js
@@ -1,16 +1,13 @@
 import { Photon } from '@generated/photon'
-import { ApolloServer, makeExecutableSchema } from '@hammerframework/hammer-api'
+import { server, makeMergedSchema } from '@hammerframework/api'
 
 import * as todo from 'src/graphql/todo'
 
-const schema = makeExecutableSchema({
-  typeDefs: [todo.schema],
-  resolvers: [todo.resolvers],
-})
+const schema = makeMergedSchema([todo])
 
 const photon = new Photon()
 
-export const handler = new ApolloServer({
+export const handler = server({
   schema,
   context: {
     photon,

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,16 +893,19 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
-"@hammerframework/api@0.0.1-alpha.13.1":
-  version "0.0.1-alpha.13.1"
-  resolved "https://registry.yarnpkg.com/@hammerframework/api/-/api-0.0.1-alpha.13.1.tgz#44949941232da183afa6a26494f6308728a0b154"
-  integrity sha512-hDM0PhQmXfT9Fwifgg780EmmvFgjQFwPEEpOcONU+XNieu+lT9YW0+JjbA2OYg32C6lP4QTKlz4F3weLxfwfjQ==
+"@hammerframework/api@0.0.1-alpha.13.2":
+  version "0.0.1-alpha.13.2"
+  resolved "https://registry.yarnpkg.com/@hammerframework/api/-/api-0.0.1-alpha.13.2.tgz#d0db6053cd45242cd2a31605c4d7e7d795b65784"
+  integrity sha512-KT+ucYAlQ8/lT2SvsaNoriwWB5zrN4fzWvgEV57uFgDBqW6DQSLMpoS8KTFUXI79FOvNnOd5f/J4qxxHaDLfMQ==
   dependencies:
     "@hammerframework/hammer-core" "^0.0.1-alpha.12.5"
+    "@types/graphql-iso-date" "^3.3.3"
     "@types/lodash.merge" "^4.6.6"
     apollo-server-lambda "2.9.9"
     core-js "3.4.1"
     graphql "^14.5.8"
+    graphql-iso-date "^3.6.1"
+    graphql-tools "4.0.6"
     lodash.merge "^4.6.2"
 
 "@hammerframework/eslint-config-hammer@0.0.1-alpha.12":
@@ -1386,6 +1389,13 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/graphql-iso-date@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@types/graphql-iso-date/-/graphql-iso-date-3.3.3.tgz#a368aa7370512a9cc87a5035c3701949ed7db9e2"
+  integrity sha512-lchvlAox/yqk2Rcrgqh+uvwc1UC9i1hap+0tqQqyYYcAica6Uw2D4mUkCNcw+WeZ8dvSS5QdtIlJuDYUf4nLXQ==
+  dependencies:
+    graphql "^14.5.3"
 
 "@types/graphql-upload@^8.0.0":
   version "8.0.3"
@@ -4594,12 +4604,17 @@ graphql-extensions@^0.10.4:
     apollo-server-env "^2.4.3"
     apollo-server-types "^0.2.5"
 
+graphql-iso-date@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz#bd2d0dc886e0f954cbbbc496bbf1d480b57ffa96"
+  integrity sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q==
+
 graphql-tag@^2.4.2, graphql-tag@^2.9.2:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
-graphql-tools@^4.0.0:
+graphql-tools@4.0.6, graphql-tools@^4.0.0:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.6.tgz#0e729e73db05ade3df10a2f92511be544972a844"
   integrity sha512-jHLQw8x3xmSNRBCsaZqelXXsFfUSUSktSCUP8KYHiX1Z9qEuwcMpAf+FkdBzk8aTAFqOlPdNZ3OI4DKKqGKUqg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,18 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
+"@hammerframework/api@0.0.1-alpha.13.1":
+  version "0.0.1-alpha.13.1"
+  resolved "https://registry.yarnpkg.com/@hammerframework/api/-/api-0.0.1-alpha.13.1.tgz#44949941232da183afa6a26494f6308728a0b154"
+  integrity sha512-hDM0PhQmXfT9Fwifgg780EmmvFgjQFwPEEpOcONU+XNieu+lT9YW0+JjbA2OYg32C6lP4QTKlz4F3weLxfwfjQ==
+  dependencies:
+    "@hammerframework/hammer-core" "^0.0.1-alpha.12.5"
+    "@types/lodash.merge" "^4.6.6"
+    apollo-server-lambda "2.9.9"
+    core-js "3.4.1"
+    graphql "^14.5.8"
+    lodash.merge "^4.6.2"
+
 "@hammerframework/eslint-config-hammer@0.0.1-alpha.12":
   version "0.0.1-alpha.12"
   resolved "https://registry.yarnpkg.com/@hammerframework/eslint-config-hammer/-/eslint-config-hammer-0.0.1-alpha.12.tgz#b1d22fee0272fdc80f7b96e686d7f12f051e9100"
@@ -911,16 +923,6 @@
     eslint-plugin-react "^7.16.0"
     eslint-plugin-react-hooks "^2.2.0"
     prettier "^1.18.2"
-
-"@hammerframework/hammer-api@^0.0.1-alpha.12.2":
-  version "0.0.1-alpha.12.2"
-  resolved "https://registry.yarnpkg.com/@hammerframework/hammer-api/-/hammer-api-0.0.1-alpha.12.2.tgz#0e9afafbd0ff1dcdb702d05f1cdde177c8c91a25"
-  integrity sha512-TvrFYE7Vw1HJYku9ZFXJo0Q4VDhirjvgPzI2fxyiuzXV8Lpz+1hA0QzALZNsbRoVrMU5FnaFM1f37xqW4Jhhaw==
-  dependencies:
-    "@hammerframework/hammer-core" "^0.0.1-alpha.12"
-    apollo-server-lambda "2.9.7"
-    core-js "3.3.3"
-    graphql "^14.5.6"
 
 "@hammerframework/hammer-core@0.0.1-alpha.12", "@hammerframework/hammer-core@^0.0.1-alpha.12":
   version "0.0.1-alpha.12"
@@ -959,6 +961,14 @@
     webpack-cli "^3.3.9"
     webpack-dev-server "^3.9.0"
     webpack-merge "^4.2.2"
+
+"@hammerframework/hammer-core@^0.0.1-alpha.12.5":
+  version "0.0.1-alpha.12.5"
+  resolved "https://registry.yarnpkg.com/@hammerframework/hammer-core/-/hammer-core-0.0.1-alpha.12.5.tgz#93a5836b60d4b4669e4d512f8ccf85b117131014"
+  integrity sha512-Se9W11w+qVt4RmSXwvDmULbybAO9HSXGCJCKbP+xdNtR9hDBg2fiIesX27vC0Nq0oXDigHffHGUeTuljB0NNIQ==
+  dependencies:
+    findup-sync "^4.0.0"
+    toml "^3.0.0"
 
 "@hammerframework/hammer-dev-server@^0.0.1-alpha.12":
   version "0.0.1-alpha.12"
@@ -1420,6 +1430,18 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/lodash.merge@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
+  integrity sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.148"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.148.tgz#ffa2786721707b335c6aa1465e6d3d74016fbd3e"
+  integrity sha512-05+sIGPev6pwpHF7NZKfP3jcXhXsIVFnYyVRT4WOB0me62E8OlWfTN+sKyt2/rqN+ETxuHAtgTSK1v71F0yncg==
 
 "@types/long@^4.0.0":
   version "4.0.0"
@@ -1954,10 +1976,10 @@ apollo-server-caching@^0.5.0:
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@^2.9.7:
-  version "2.9.7"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.9.7.tgz#0f32344af90dec445ac780be95350bfa736fc416"
-  integrity sha512-EqKyROy+21sM93YHjGpy6wlnzK/vH0fnZh7RCf3uB69aQ3OjgdP4AQ5oWRQ62NDN+aoic7OLhChSDJeDonq/NQ==
+apollo-server-core@^2.9.9:
+  version "2.9.9"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.9.9.tgz#73df4989ac0ad09d20c20ef3e06f8c816bc7a13f"
+  integrity sha512-JxtYDasqeem5qUwPrCVh2IsBOgSQF4MKrRgy8dpxd+ymWfaaVelCUows1VE8vghgRxqDExnM9ibOxcZeI6mO6g==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.0"
     "@apollographql/graphql-playground-html" "1.6.24"
@@ -1994,14 +2016,14 @@ apollo-server-errors@^2.3.4:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.3.4.tgz#b70ef01322f616cbcd876f3e0168a1a86b82db34"
   integrity sha512-Y0PKQvkrb2Kd18d1NPlHdSqmlr8TgqJ7JQcNIfhNDgdb45CnqZlxL1abuIRhr8tiw8OhVOcFxz2KyglBi8TKdA==
 
-apollo-server-lambda@2.9.7:
-  version "2.9.7"
-  resolved "https://registry.yarnpkg.com/apollo-server-lambda/-/apollo-server-lambda-2.9.7.tgz#322becf0d82619cc74ffab5d668ac364dc0f52ee"
-  integrity sha512-6c4xbsWLYUZKdYw2bYrIEHZEHXJcAX6mzivzwoldqlnDu8VdrDipfh5QnBvJ9tRy08E4K8YZLjpGxKL0/l1yVw==
+apollo-server-lambda@2.9.9:
+  version "2.9.9"
+  resolved "https://registry.yarnpkg.com/apollo-server-lambda/-/apollo-server-lambda-2.9.9.tgz#bbb258cf32d79044b1fd7364d2e2682169f0edf2"
+  integrity sha512-5kcy9zRKmP2WoBkoVMBgw1XzctpxQQg5R2t1f8PrEurvp4EVk+dUOQI65XE1exJzpF1Ik9EbFwPc7hcYFJjKog==
   dependencies:
     "@apollographql/graphql-playground-html" "1.6.24"
     "@types/aws-lambda" "^8.10.31"
-    apollo-server-core "^2.9.7"
+    apollo-server-core "^2.9.9"
     apollo-server-env "^2.4.3"
     apollo-server-types "^0.2.5"
     graphql-tools "^4.0.0"
@@ -3076,6 +3098,11 @@ core-js@3.3.5, core-js@^3.0.1, core-js@^3.2.1:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.5.tgz#58d20f48a95a07304b62ff752742b82b56431ed8"
   integrity sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==
+
+core-js@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
+  integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==
 
 core-js@^2.5.7, core-js@^2.6.5:
   version "2.6.10"
@@ -4593,7 +4620,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-graphql@^14.5.3, graphql@^14.5.6, graphql@^14.5.8:
+graphql@^14.5.3, graphql@^14.5.8:
   version "14.5.8"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
   integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
@@ -5622,6 +5649,11 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -6030,13 +6062,6 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
-
-nexus@0.12.0-beta.14:
-  version "0.12.0-beta.14"
-  resolved "https://registry.yarnpkg.com/nexus/-/nexus-0.12.0-beta.14.tgz#541a0d41ce92cfa1a54d3199e9048fc92c3fc36a"
-  integrity sha512-jWHi+j9YhTwZZ0n82STJRNoU+HfrnrNGIw1sZs0c/9iscr1ewwpeQ7Lo+so0fIaboErAz47CHVcAn1BSr8kiLg==
-  dependencies:
-    tslib "^1.9.3"
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
`@hammerframework/api` added a helper to merge the type definitions and resolvers together into a single executable schema. This example repo only exports a single schema group "todo", so it's kinda pointless to use it here, but it's more helpful to have a single approach for all the example repos.