### PR TITLE
Add `__filename` to webpack files

### DIFF
--- a/web/config/webpack.common.js
+++ b/web/config/webpack.common.js
@@ -63,10 +63,10 @@ module.exports = (webpackEnv) => {
         publicPath: true,
       }),
       isEnvProduction &&
-      new MiniCssExtractPlugin({
-        filename: '[name].[contenthash:8].css',
-        chunkFilename: '[name].[contenthash:8].css',
-      }),
+        new MiniCssExtractPlugin({
+          filename: '[name].[contenthash:8].css',
+          chunkFilename: '[name].[contenthash:8].css',
+        }),
       new HtmlWebpackPlugin({
         template: './src/index.html',
       }),
@@ -121,7 +121,7 @@ module.exports = (webpackEnv) => {
             },
             {
               test: /\.svg$/,
-              loader: 'svg-inline-loader'
+              loader: 'svg-inline-loader',
             },
             ...getStyleLoaders(),
             {

--- a/web/config/webpack.common.js
+++ b/web/config/webpack.common.js
@@ -79,6 +79,10 @@ module.exports = (webpackEnv) => {
         '__HAMMER__.apiProxyPath': JSON.stringify(
           hammerConfig.web.apiProxyPath
         ),
+        __filename: webpack.DefinePlugin.runtimeValue((runtimeValue) => {
+          // absolute path of imported file
+          return JSON.stringify(runtimeValue.module.resource)
+        }),
       }),
       new FaviconsWebpackPlugin(
         path.join(hammerConfig.baseDir, 'web/src/favicon.png')


### PR DESCRIPTION
This adds the `__filename` "dynamic constant" which is run during compile time. Webpack's DefinePlugin will replace any `__filename` strings with the absolute path of the current module.

```js
// in `./web/pages/HomePage/Homepage.js`
console.log(__filename)
// will output `/home/dev/hammer/example-todos/web/pages/HomePage/Homepage.js`
```
We may want to consider using the relative value instead, or only making this available during development.